### PR TITLE
compatibility to spt 3.9.4 (and 3.9.5?)

### DIFF
--- a/MarsyApp-WhiteBoxFix.csproj
+++ b/MarsyApp-WhiteBoxFix.csproj
@@ -32,19 +32,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\Shared\3.8.1\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath>..\Shared\3.9.4\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Aki.Reflection">
-      <HintPath>..\Shared\3.8.1\EscapeFromTarkov_Data\Managed\Aki.Reflection.dll</HintPath>
+      <HintPath>..\Shared\3.9.4\EscapeFromTarkov_Data\Managed\Aki.Reflection.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\Shared\3.8.1\EscapeFromTarkov_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\Shared\3.9.4\EscapeFromTarkov_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>..\Shared\3.8.1\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath>..\Shared\3.9.4\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="Comfort">
-      <HintPath>..\Shared\3.8.1\EscapeFromTarkov_Data\Managed\Comfort.dll</HintPath>
+      <HintPath>..\Shared\3.9.4\EscapeFromTarkov_Data\Managed\Comfort.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -55,18 +55,18 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\Shared\3.8.1\EscapeFromTarkov_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\Shared\3.9.4\EscapeFromTarkov_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\Shared\3.8.1\EscapeFromTarkov_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\Shared\3.9.4\EscapeFromTarkov_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Shared\3.8.1\EscapeFromTarkov_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\Shared\3.9.4\EscapeFromTarkov_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Shared\3.8.1\EscapeFromTarkov_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>..\Shared\3.9.4\EscapeFromTarkov_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Patches.cs
+++ b/Patches.cs
@@ -1,7 +1,7 @@
 ﻿using EFT.InventoryLogic;
 using System.Collections.Generic;
 using System.Reflection;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using System;
 using System.Linq;
 using HarmonyLib;

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,2 +1,2 @@
 using MarsyApp.WhiteBoxFix.VersionChecker;
-[assembly: TarkovVersion(29197)]
+[assembly: TarkovVersion(30626)]

--- a/WhiteBoxFix.cs
+++ b/WhiteBoxFix.cs
@@ -2,7 +2,7 @@
 
 namespace WhiteBoxFix
 {
-    [BepInPlugin("com.MarsyApp.WhiteBoxFix", "MarsyApp-WhiteBoxFix", "1.0.0")]
+    [BepInPlugin("com.MarsyApp.WhiteBoxFix", "MarsyApp-WhiteBoxFix", "1.1.0")]
     public class WhiteBoxFix : BaseUnityPlugin
     {
         private void Awake()


### PR DESCRIPTION
I'm still on 3.9.4 since "Questing Bots" is holding me back from 3.9.5, which in combination breaks any bot spawns - but 3.9.4 <-> 3.9.5 should be no problem in this case